### PR TITLE
Blocking client points to valid socket

### DIFF
--- a/concoord/blockingclientproxy.py
+++ b/concoord/blockingclientproxy.py
@@ -160,8 +160,8 @@ class ClientProxy():
             print "Unexpected Client Reply Code: %d" % reqdesc.reply.replycode
 
     def recv_loop(self, *args):
-        socketset = [self.socket]
         while True:
+            socketset = [self.socket]
             try:
                 needreconfig = False
                 inputready,outputready,exceptready = select.select(socketset, [], socketset, 0)


### PR DESCRIPTION
When client loses connection over the connected node now it connects to the next one. It used to keep a reference to the old socket connection and it threw a bad file descriptor exception.